### PR TITLE
fix navbar: correct logo style using clsx

### DIFF
--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -42,12 +42,12 @@ export const Navbar: FC<{ lang: Language, links: Links }> = ({
       <div className={clsx(ui.flex, ui['flex-row'], styles.mobileMenu)}>
         <Link href={langPrefix || '/'} onClick={() => setOpen(false)}>
           <EnsNavIcon
-            className={(styles.logo, styles.tabletOnly)}
+            className={clsx(styles.logo, styles.tabletOnly)}
           />
           <img
             src="/assets/ens_logo_text_dark.svg"
             alt="ENS"
-            className={(styles.logo, styles.desktopOnly)}
+            className={clsx(styles.logo, styles.desktopOnly)}
           />
         </Link>
         <div className={clsx(ui.flex, ui['flex-row'], ui['space-x-8'], ui['flex-center'])}>


### PR DESCRIPTION
Logo styles were not being properly applied due to incorrect classname syntax in navbar component.

```diff
- className={(styles.logo, styles.tabletOnly)}
+ className={clsx(styles.logo, styles.tabletOnly)}
```
```diff
- className={(styles.logo, styles.desktopOnly)}
+ className={clsx(styles.logo, styles.desktopOnly)}
```
- fixed logo width 1rem
- restored proper responsive behavior
- aligned with projects clsx pattern
