### PR TITLE
Remove Google Sheets link from null-byte vulnerability blog post

### DIFF
--- a/posts/005_post_mortem_null_byte_vulnerability/readme.mdx
+++ b/posts/005_post_mortem_null_byte_vulnerability/readme.mdx
@@ -38,7 +38,7 @@ Semi - automated deployment for metadata-service, all the code merged into maste
 
 ## Impact
 
-There are 14 incidents found, some were taken down by marketplaces after our fixes, the others taken down after we gather [the full list](https://docs.google.com/spreadsheets/u/2/d/1qbLLZYNvFGDhcGSIPY-bLAHXjnuS3qZJrN7fQQIrVl0/edit).
+There are 14 incidents found, some were taken down by marketplaces after our fixes, the others taken down after we gather the full list.
 
 ## Lessons Learned
 


### PR DESCRIPTION
Removed external link to Google Sheets document from the Impact section to maintain better privacy and security.

🤖 Generated with [Claude Code](https://claude.ai/code)